### PR TITLE
Update Kotlin to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.1.0-1.0.1 - 2024-12-19
+
+- Upgrade Kotlin to 2.1.0
+
 ## 2.0.21-1.0.1 - 2024-10-11
 
 - Upgrade Kotlin to 2.0.21

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Define the PF4J dependency in your pom.xml:
 <dependency>
     <groupId>org.pf4j</groupId>
     <artifactId>pf4j</artifactId>
-    <version>3.3.1</version>
+    <version>3.13.0</version>
 </dependency>
 
 ```
@@ -30,7 +30,7 @@ Define the kotlin-maven-plugin in your pom.xml:
 <plugin>
     <groupId>org.jetbrains.kotlin</groupId>
     <artifactId>kotlin-maven-plugin</artifactId>
-    <version>2.0.21</version>
+    <version>2.1.0</version>
     <executions>
         <execution>
             <id>compile</id>
@@ -57,12 +57,12 @@ Define the kotlin-maven-plugin in your pom.xml:
         <dependency>
             <groupId>com.dyescape</groupId>
             <artifactId>kotlin-maven-symbol-processing</artifactId>
-            <version>1.6</version>
+            <version>1.7</version>
         </dependency>
         <dependency>
             <artifactId>pf4j-kotlin-symbol-processing</artifactId>
             <groupId>care.better.pf4j</groupId>
-            <version>2.0.21-1.0.1</version>
+            <version>2.1.0-1.0.1</version>
         </dependency>
     </dependencies>
 </plugin>
@@ -84,11 +84,11 @@ Apply the com.google.devtools.ksp plugin with the specified version and pf4j-kot
 
 ```kotlin
 plugins {
-    id("com.google.devtools.ksp") version "2.0.21-1.0.25"
+    id("com.google.devtools.ksp") version "2.1.0-1.0.29"
 }
 
 dependencies {
-    implementation("org.pf4j:pf4j:3.3.1")
-    ksp("care.better.pf4j:pf4j-kotlin-symbol-processing:2.0.21-1.0.1")
+    implementation("org.pf4j:pf4j:3.13.0")
+    ksp("care.better.pf4j:pf4j-kotlin-symbol-processing:2.1.0-1.0.1")
 }
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <artifactId>pf4j-kotlin-symbol-processing</artifactId>
     <groupId>care.better.pf4j</groupId>
-    <version>2.0.22-1.0.1-SNAPSHOT</version>
+    <version>2.1.0-1.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -34,9 +34,9 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
 
-        <pf4j.version>3.3.1</pf4j.version>
-        <kotlin.version>2.0.21</kotlin.version>
-        <symbol-processing-api.version>2.0.21-1.0.25</symbol-processing-api.version>
+        <pf4j.version>3.13.0</pf4j.version>
+        <kotlin.version>2.1.0</kotlin.version>
+        <symbol-processing-api.version>2.1.0-1.0.29</symbol-processing-api.version>
 
         <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>


### PR DESCRIPTION
This PR updates the following dependencies:

- Kotlin to 2.1.0
- KSP to 2.1.0-1.0.29
- Maven plugin "kotlin-maven-symbol-processing" to 1.7

Additionally I updated the PF4J version from the README.md to 3.13.0

CHANGELOG.md has also been updated to reflect the changes

All changes have been tested by using the new version in Gameyfin and no errors have been observed.